### PR TITLE
Add draggable property to tabs

### DIFF
--- a/Runtime/Widgets/Tabs.cs
+++ b/Runtime/Widgets/Tabs.cs
@@ -9,6 +9,7 @@ namespace UniMob.UI.Widgets
 
         public TabController TabController { get; }
         public bool UseMask { get; set; } = true;
+        public bool Draggable {get; set;} = true; 
         public AxisSize CrossAxisSize { get; set; } = AxisSize.Min;
         public AxisSize MainAxisSize { get; set; } = AxisSize.Min;
         public WidgetSize? Size { get; set; }
@@ -25,6 +26,7 @@ namespace UniMob.UI.Widgets
         public bool UseMask => Widget.UseMask;
 
         [Atom] public WidgetSize InnerSize => CalculateInnerSize();
+        [Atom] public bool Draggable => Widget.Draggable;
 
         public override WidgetSize CalculateSize()
         {

--- a/Runtime/Widgets/TabsView.cs
+++ b/Runtime/Widgets/TabsView.cs
@@ -89,7 +89,7 @@ namespace UniMob.UI.Widgets
 
         void IBeginDragHandler.OnBeginDrag(PointerEventData eventData)
         {
-            _routeToParent = Mathf.Abs(eventData.delta.x) < Mathf.Abs(eventData.delta.y);
+            _routeToParent = Mathf.Abs(eventData.delta.x) < Mathf.Abs(eventData.delta.y) || (HasState && !State.Draggable);
 
             if (_routeToParent)
             {
@@ -163,6 +163,8 @@ namespace UniMob.UI.Widgets
         TabController TabController { get; }
 
         bool UseMask { get; }
+
+        bool Draggable { get; }
 
         IState[] Children { get; }
     }


### PR DESCRIPTION
I am not sure whether you accept contributions.
However, I found myself using the Tabs component but I did not want the dragging behaviour to scroll the tab. So I implemented it.

Add a new property `Draggable` to `ITabState` with default value `true` (maintains compatibility with previous behaviour).
Setting it to `false` suppresses the swipe-to-change-tab behaviour by routing the events to the parent.