### PR TITLE
Add editor-only logic to reset static field on play mode enter.

### DIFF
--- a/Runtime/Internal/Pooling/GameObjectPool.cs
+++ b/Runtime/Internal/Pooling/GameObjectPool.cs
@@ -12,6 +12,15 @@ namespace UniMob.UI.Internal.Pooling
     {
         private static readonly Dictionary<int, Pool> Pools = new Dictionary<int, Pool>();
 
+
+        #if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod]
+        static void OnRuntimeLoad()
+        {
+            Pools.Clear();
+        }
+        #endif
+
         public static Pool GetPool([NotNull] GameObject prefab)
         {
             if (prefab == null) throw new ArgumentNullException(nameof(prefab));
@@ -157,7 +166,8 @@ namespace UniMob.UI.Internal.Pooling
             private void EditorUpdateName()
             {
 #if UNITY_EDITOR
-                name = $"{Prefab.name} Pool ({CountOfObjectsInPool})";
+                if(Prefab != null)
+                    name = $"{Prefab.name} Pool ({CountOfObjectsInPool})";
 #endif
             }
         }

--- a/Runtime/StateProvider.cs
+++ b/Runtime/StateProvider.cs
@@ -7,6 +7,14 @@ namespace UniMob.UI
     {
         private static readonly Dictionary<Type, Func<State>> StateFactories = new Dictionary<Type, Func<State>>();
 
+        #if UNITY_EDITOR
+        [UnityEngine.RuntimeInitializeOnLoadMethod]
+        static void OnRuntimeLoad()
+        {
+            StateFactories.Clear();
+        }
+        #endif
+
         public static void Register<TWidget>(Func<State> factory)
             where TWidget : Widget
         {

--- a/Runtime/UniMobViewContext.cs
+++ b/Runtime/UniMobViewContext.cs
@@ -10,10 +10,23 @@ namespace UniMob.UI
 
         internal static IViewTreeElement CurrentElement;
 
-        public static readonly IViewLoader Loader = new MultiViewLoader(
+        public static IViewLoader Loader = new MultiViewLoader(
             new InternalViewLoader(),
             new PrefabViewLoader(),
             new BuiltinResourcesViewLoader(),
             new AddressableViewLoader());
+
+        #if UNITY_EDITOR
+        [RuntimeInitializeOnLoadMethod]
+        static void OnRuntimeLoad()
+        {
+            CurrentElement = null;
+            Loader = new MultiViewLoader(
+            new InternalViewLoader(),
+            new PrefabViewLoader(),
+            new BuiltinResourcesViewLoader(),
+            new AddressableViewLoader());
+        }
+        #endif
     }
 }


### PR DESCRIPTION
Resetting the static fields upon entering Play mode (using the [`[RuntimeInitializeOnLoadMethod]`](https://docs.unity3d.com/ScriptReference/RuntimeInitializeOnLoadMethodAttribute.html)) we can develop in the editor without having Unity [reload the domain](https://docs.unity3d.com/Manual/DomainReloading.html).