### PR TITLE
Scroll grid with unbounded width children

### DIFF
--- a/Runtime/RectPadding.cs
+++ b/Runtime/RectPadding.cs
@@ -26,5 +26,10 @@ namespace UniMob.UI
 
         public float Horizontal => Left + Right;
         public float Vertical => Top + Bottom;
+
+
+        public static RectPadding Symmetric(float horizontal, float vertical) => new (horizontal, horizontal, vertical, vertical);
+        public static RectPadding All(float padding) => Symmetric(padding, padding);
+        public static RectPadding Only(float left = 0, float right = 0, float top = 0, float bottom = 0) => new (left, right, top, bottom);
     }
 }

--- a/Runtime/TabController.cs
+++ b/Runtime/TabController.cs
@@ -45,6 +45,7 @@ namespace UniMob.UI
                 if (Mathf.Approximately(Duration, 0f))
                 {
                     IndexIsChanging = false;
+                    Value = newIndex,
                 }
                 else
                 {

--- a/Runtime/TabController.cs
+++ b/Runtime/TabController.cs
@@ -46,7 +46,6 @@ namespace UniMob.UI
                 {
                     Value = Index;
                     IndexIsChanging = false;
-                    Value = newIndex;
                 }
                 else
                 {

--- a/Runtime/TabController.cs
+++ b/Runtime/TabController.cs
@@ -45,7 +45,7 @@ namespace UniMob.UI
                 if (Mathf.Approximately(Duration, 0f))
                 {
                     IndexIsChanging = false;
-                    Value = newIndex,
+                    Value = newIndex;
                 }
                 else
                 {

--- a/Runtime/Widgets/ScrollGridFlow.cs
+++ b/Runtime/Widgets/ScrollGridFlow.cs
@@ -49,7 +49,7 @@ namespace UniMob.UI.Widgets
             {
                 var childSize = child.Size;
 
-                if (float.IsInfinity(childSize.MaxWidth) || float.IsInfinity(childSize.MaxHeight))
+                if (float.IsInfinity(childSize.MaxHeight))
                 {
                     continue;
                 }

--- a/Runtime/Widgets/ScrollGridFlowView.cs
+++ b/Runtime/Widgets/ScrollGridFlowView.cs
@@ -270,6 +270,22 @@ namespace UniMob.UI.Widgets
                     newLine = false;
                     lineHeight = childSize.y;
                     var lineWidth = childSize.x;
+
+                    if (float.IsInfinity(childSize.x))
+                    {
+                        if (lineMaxChildCount == 1)
+                        {
+                            // This is not right, in theory, as it messes with the cornerPosition.x calculation.
+                            // However, as long as there is only one child per line, it works.
+                            lineWidth = 0;
+                        }
+                        else
+                        {
+                            Debug.LogError($"Cannot render multiple horizontally stretched widgets inside ScrollGridFlow.\n" +
+                                $"Try to wrap {child.GetType().Name} into another widget of fixed width or to set {nameof(state.MaxCrossAxisCount)} to 1");
+                        }
+                    }
+
                     var lineChildCount = 1;
 
                     for (int i = childIndex + 1; i < children.Length; i++)

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.codewriter.unimob.ui",
   "displayName": "UniMob.UI",
   "description": "A declarative library for building reactive user interfaces",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "unity": "2019.3",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
This partially addresses #18, in that it behaves more or less consistently with a ScrollList if `MaxCrossAxisCount == 1` and children have infinite width.

Known limitations:
- `MaxCrossAxisExtent` is ignored.
- There is a hard assertion that `MaxCrossAxisCount` equals one.
