### PR TITLE
Add support for a single width unbounded widget in ScrollGridFlow

### DIFF
--- a/Runtime/Widgets/ScrollGridFlow.cs
+++ b/Runtime/Widgets/ScrollGridFlow.cs
@@ -49,7 +49,7 @@ namespace UniMob.UI.Widgets
             {
                 var childSize = child.Size;
 
-                if (float.IsInfinity(childSize.MaxWidth) || float.IsInfinity(childSize.MaxHeight))
+                if (float.IsInfinity(childSize.MaxHeight))
                 {
                     continue;
                 }

--- a/Runtime/Widgets/ScrollGridFlowView.cs
+++ b/Runtime/Widgets/ScrollGridFlowView.cs
@@ -270,6 +270,22 @@ namespace UniMob.UI.Widgets
                     newLine = false;
                     lineHeight = childSize.y;
                     var lineWidth = childSize.x;
+
+                    if (float.IsInfinity(childSize.x))
+                    {
+                        if (lineMaxChildCount == 1)
+                        {
+                            // This is not right, in theory, as it messes with the cornerPosition.x calculation.
+                            // However, as long as there is only one child per line, it works.
+                            lineWidth = 0;
+                        }
+                        else
+                        {
+                            Debug.LogError($"Cannot render multiple horizontally stretched widgets inside ScrollGridFlow.\n" +
+                                $"Try to wrap {child.GetType().Name} into another widget of fixed width or to set {nameof(state.MaxCrossAxisCount)} to 1");
+                        }
+                    }
+
                     var lineChildCount = 1;
 
                     for (int i = childIndex + 1; i < children.Length; i++)


### PR DESCRIPTION
This partially addresses #18, in that it behaves more or less consistently with a ScrollList if `MaxCrossAxisCount == 1` and children have infinite width.

Known limitations:
- `MaxCrossAxisExtent` is ignored.
- There is a hard assertion that `MaxCrossAxisCount` equals one.